### PR TITLE
46 Fix publish commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
-      - run: tsc
-      - run: yarn npm publish --provenance --access public
+      - run: yarn build
+      - run: yarn publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Does this fix a bug, implement a new feature, etc? -->
- Use `yarn build` instead of `tsc`
- Use `yarn publish ...` instead of `yarn npm publish`, which doesn't work with yarn 1.x

### Related Issue(s)

<!-- Reference the issue this PR relates to -->
<!-- Use keywords if possible (ex. Closes #10 ) -->
<!-- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->
Closes #46 

## Screenshots

<!-- (if applicable) -->
