### PR TITLE
Prevent publish job if version does not change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,21 @@ jobs:
         run: pnpm lint
       - name: Build project
         run: pnpm run build
+      - name: Extract package version
+        id: extract_version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+      - name: Check if version matches tag
+        id: check_version
+        run: |
+          tag_name="${{ github.ref_name }}"
+          package_version="${{ steps.extract_version.outputs.version }}"
+          if [[ "$tag_name" == "$package_version" || "$tag_name" == *"$package_version-alpha"* || "$tag_name" == *"$package_version-beta"* || "$tag_name" == *"$package_version-canary"* ]]; then
+            echo "::set-output name=should_publish::true"
+          else
+            echo "::set-output name=should_publish::false"
+          fi
       - name: Publish package to NPM
+        if: steps.check_version.outputs.should_publish == 'true'
         run: |
           if [[ "${{ github.ref_name }}" == *-alpha* ]]; then
             pnpm publish --access public --tag alpha


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
<!-- Does this fix a bug, implement a new feature, etc? -->
This should prevent the publish job from failing when I don't actually intend for it to run. Not all merges should trigger a deploy/publish.

### Related Issue(s)

<!-- Reference the issue this PR relates to -->
<!-- Use keywords if possible (ex. Closes #10 ) -->
<!-- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Screenshots

<!-- (if applicable) -->
